### PR TITLE
Small fixes added

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
@@ -9,7 +10,7 @@
   <component name="VisualizationToolProject">
     <option name="state">
       <ProjectState>
-        <option name="scale" value="0.6741016109045849" />
+        <option name="scale" value="0.67" />
       </ProjectState>
     </option>
   </component>

--- a/app/src/main/java/edu/tacoma/uw/bloommoods/Account.java
+++ b/app/src/main/java/edu/tacoma/uw/bloommoods/Account.java
@@ -84,7 +84,7 @@ public class Account {
 
     public void setPassword(String password) {
         if (!isValidPassword(password)) {
-            throw new IllegalArgumentException("Password must be at last 6 chars long with at least 1 digit and 1 symbol.");
+            throw new IllegalArgumentException("Password must be at last 6 characters long with at least 1 digit and 1 symbol");
         }
         this.myPassword = password;
     }

--- a/app/src/main/java/edu/tacoma/uw/bloommoods/Account.java
+++ b/app/src/main/java/edu/tacoma/uw/bloommoods/Account.java
@@ -16,9 +16,15 @@ public class Account {
      * @param password The password to set.
      * @throws IllegalArgumentException if the email or password is invalid.
      */
-    public Account(String email, String password) {
-        setEmail(email);
-        setPassword(password);
+    public Account(String email, String password, Boolean validate) {
+        if (validate) {
+            setEmail(email);
+            setPassword(password);
+        } else {
+            myEmail = email;
+            myPassword = password;
+        }
+
     }
 
     /**
@@ -78,7 +84,7 @@ public class Account {
 
     public void setPassword(String password) {
         if (!isValidPassword(password)) {
-            throw new IllegalArgumentException("Invalid password");
+            throw new IllegalArgumentException("Password must be at last 6 chars long with at least 1 digit and 1 symbol.");
         }
         this.myPassword = password;
     }

--- a/app/src/main/java/edu/tacoma/uw/bloommoods/AccountFragment.java
+++ b/app/src/main/java/edu/tacoma/uw/bloommoods/AccountFragment.java
@@ -1,7 +1,9 @@
 package edu.tacoma.uw.bloommoods;
 
 import android.app.Activity;
+import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.graphics.Color;
 import android.os.Bundle;
 import android.util.Log;
@@ -82,13 +84,23 @@ public class AccountFragment extends Fragment {
                 updatePassword();
             }
         });
-        binding.logoutButton.setOnClickListener(v ->{
+
+        binding.logoutButton.setOnClickListener(v -> {
             Activity activity = getActivity();
-            if(activity instanceof MainActivity){
+            if (activity instanceof MainActivity) {
                 ((MainActivity) activity).hideBottomNavigation();
+
+                // Clear the SharedPreferences
+                SharedPreferences sharedPreferences = getActivity().getSharedPreferences(getString(R.string.SignIN_PREFS),
+                        Context.MODE_PRIVATE);
+                sharedPreferences.edit().putBoolean(getString(R.string.SignedIN), false).apply();
+                sharedPreferences.edit().putInt("userId", 0).apply();
+
+                // Navigate to the login fragment
+                Navigation.findNavController(getView()).navigate(R.id.loginFragment);
             }
-            Navigation.findNavController(getView()).navigate(R.id.loginFragment);
         });
+
         binding.referButton.setOnClickListener(v -> shareAppLink());
 
     }

--- a/app/src/main/java/edu/tacoma/uw/bloommoods/LoginFragment.java
+++ b/app/src/main/java/edu/tacoma/uw/bloommoods/LoginFragment.java
@@ -68,11 +68,10 @@ public class LoginFragment extends Fragment {
         String pwd = String.valueOf(mBinding.pwdEdit.getText());
         Account account;
         if(email.isEmpty() || pwd.isEmpty()){
-            //throw a toast
-            Toast.makeText(this.getContext(), "All fields are required ", Toast.LENGTH_LONG).show();
+            mBinding.errorLoginTextview.setText("All fields are required");
         }else {
             try {
-                account = new Account(email, pwd);
+                account = new Account(email, pwd, false);
             } catch (IllegalArgumentException ie) {
                 Log.e(TAG, ie.getMessage());
                 Toast.makeText(getContext(), ie.getMessage(), Toast.LENGTH_LONG).show();
@@ -97,9 +96,7 @@ public class LoginFragment extends Fragment {
                     String result = response.getString("result");
                     if ("failed to login".equals(result)) {
                         // If the result is "failed to login", display the error message to the user
-                        String errorMessage = response.optString("message", "invalid credentials");
-                        Toast.makeText(getContext(), "Login failed: " + errorMessage, Toast.LENGTH_LONG).show();
-                        mBinding.errorLoginTextview.setText("User failed to authenticate");
+                        mBinding.errorLoginTextview.setText("Invalid credentials");
                     } else if ("success".equals(result)) {
                         Toast.makeText(getContext(), "Login successful", Toast.LENGTH_LONG).show();
 
@@ -111,6 +108,7 @@ public class LoginFragment extends Fragment {
                             Activity activity = getActivity();
                             if (activity instanceof MainActivity) {
                                 ((MainActivity) activity).showBottomNavigation();
+                                ((MainActivity) activity).setupBottomNavigation();
                             }
                             Navigation.findNavController(getView()).navigate(R.id.action_loginFragment_to_homeFragment);
                         }

--- a/app/src/main/java/edu/tacoma/uw/bloommoods/RegisterFragment.java
+++ b/app/src/main/java/edu/tacoma/uw/bloommoods/RegisterFragment.java
@@ -69,17 +69,15 @@ public class RegisterFragment extends Fragment {
         String pwd = String.valueOf(mBinding.pwdEdit.getText());
         String name = String.valueOf(mBinding.nameEdit.getText());
         if (email.isEmpty() || pwd.isEmpty() || name.isEmpty()) {
-            //throw a toast
-            Toast.makeText(this.getContext(), "All fields are required ", Toast.LENGTH_LONG).show();
+            mBinding.textError.setText("All fields are required");
 
         } else {
             try {
-                Account account = new Account(email, pwd);
+                Account account = new Account(email, pwd, true);
                 Log.i(TAG, email);
                 mRegisterUserViewModel.addUser(account, name);
             } catch (IllegalArgumentException ie) {
                 Log.e(TAG, ie.getMessage());
-                Toast.makeText(this.getContext(), ie.getMessage(), Toast.LENGTH_LONG).show();
                 mBinding.textError.setText(ie.getMessage());
             }
         }
@@ -92,7 +90,6 @@ public class RegisterFragment extends Fragment {
                     int errorCode = response.getInt("error_code");
                     if (errorCode == 1062) {
                         String errorMessage = "Email already exists.";
-                        Toast.makeText(this.getContext(), errorMessage, Toast.LENGTH_LONG).show();
                         mBinding.textError.setText(errorMessage);
                     }
                 } else {

--- a/app/src/main/res/layout/fragment_login.xml
+++ b/app/src/main/res/layout/fragment_login.xml
@@ -103,12 +103,18 @@
         app:layout_constraintTop_toBottomOf="@+id/pwd_edit" />
 
     <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
         android:id="@+id/error_login_textview"
-        android:textColor="@color/design_default_color_error"
-        android:layout_gravity="center_horizontal" />
-
+        android:layout_width="280dp"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginStart="75dp"
+        android:layout_marginTop="28dp"
+        android:textSize="17sp"
+        android:background="@android:color/transparent"
+        android:fontFamily="@font/playfair_display"
+        android:textColor="@color/red"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/pwd_edit" />
 
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_register.xml
+++ b/app/src/main/res/layout/fragment_register.xml
@@ -117,11 +117,17 @@
         app:layout_constraintTop_toBottomOf="@+id/pwd_edit" />
 
     <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
         android:id="@+id/textError"
+        android:layout_width="280dp"
+        android:layout_height="wrap_content"
         android:layout_gravity="bottom"
-        android:textColor="@color/design_default_color_error" />
+        android:layout_marginStart="75dp"
+        android:layout_marginTop="15dp"
+        android:fontFamily="@font/playfair_display"
+        android:textColor="@color/red"
+        android:textSize="14sp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/pwd_edit" />
 
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/test/java/edu/tacoma/uw/bloommoods/PlantViewModelUnitTest.java
+++ b/app/src/test/java/edu/tacoma/uw/bloommoods/PlantViewModelUnitTest.java
@@ -1,0 +1,4 @@
+package edu.tacoma.uw.bloommoods;
+
+public class PlantViewModelUnitTest {
+}


### PR DESCRIPTION
- Fixed logout so that it reset the sharedpreference values when logging out.
- Added boolean param to Account constructor to support login vs sign up: login doesn't need to validate inputs, will just use the entered credentials as it is for API call.
![image](https://github.com/Hossain2024/BloomMoods/assets/115098403/7f4d6606-900f-43a5-9563-b5660deeccb9)
- Fixed error message texts on login and register, and now toast will only show when login/signup is successful, otherwise error will be on screen.
![image](https://github.com/Hossain2024/BloomMoods/assets/115098403/f6e8c604-97fd-424f-a0a7-02b3b676c492)
![image](https://github.com/Hossain2024/BloomMoods/assets/115098403/f229a3ca-49f6-4c03-95c7-0c4de044f2ed)
![image](https://github.com/Hossain2024/BloomMoods/assets/115098403/ad4b0d05-16ff-4a19-94b0-e9fe90ecb08c)
![image](https://github.com/Hossain2024/BloomMoods/assets/115098403/2bb7715f-f8a1-480e-888c-131dd509552b)
